### PR TITLE
Add: Well-known SDXL resolutions to the latent-size pulldown.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -31,11 +31,20 @@ Illustrious Prompt Suite and resources.
 """
 # Global resolutions dictionary - primary resolution selector
 RESOLUTIONS: Dict[str, str] = {
+    "Portrait | SDXL Well Known (5:12) - 640x1536": "640x1536",
+    "Portrait | SDXL Well Known (4:7) - 768x1344": "768x1344",
+    "Portrait | SDXL Well Known (13:19) - 832x1216": "832x1216",
+    "Portrait | SDXL Well Known (7:9) - 896x1152": "896x1152",
     "Portrait | Character Sheet (2:3) - 832x1248": "832x1248",
     "Portrait | VN CG (3:4) - 880x1176": "880x1176",
     "Portrait | Manga Cover (4:5) - 912x1144": "912x1144",
     "Mobile | Vertical Story (9:16) - 768x1360": "768x1360",
     "Square | Model Preview (1:1) - 1024x1024": "1024x1024",
+    "Landscape | SDXL Well Known (12:5) - 1536x640": "1536x640",
+    "Landscape | SDXL Well Known (7:4) - 1344x768": "1344x768",
+    "Landscape | SDXL Well Known (19:13) - 1216x832": "1216x832",
+    "Landscape | SDXL Well Known (9:7) - 1152x896": "1152x896",
+    "Landscape | Character Sheet (2:3) - 832x1248": "832x1248",
     "Retro Anime TV (4:3) - 1176x888": "1176x888",
     "Key Visual Poster (1.43:1) - 1224x856": "1224x856",
     "Wide Panel (1.66:1) - 1312x792": "1312x792",


### PR DESCRIPTION
Hello. First, I want to express my appreciation for your excellent work on this custom node.

I've found it would be more convenient to include some well-known SDXL resolutions directly in the list for the `Empty Latent Image` node.
I know that the `enable_native_resolution` feature does something similar. However, I haven't been able to get it to produce some specific resolutions I'm familiar with, like `832x1216`. This PR adds those common resolutions that are often suggested by other custom nodes and community guidelines.

Please let me know if I'm misunderstanding something or if this change isn't necessary. Thank you.